### PR TITLE
Md support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1012,19 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "comrak"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab87129dce2f2d7e75e753b1df0e5093b27dec8fa5970b6eb51280faacb25bd6"
+dependencies = [
+ "caseless",
+ "entities",
+ "jetscii",
+ "typed-arena",
+ "unicode_categories",
 ]
 
 [[package]]
@@ -1447,6 +1469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,6 +1806,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "frostmark"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ebfe31be0194c0de0c074e1aa09c4762ae68100152f81772dc6a8f3adc970a"
+dependencies = [
+ "bitflags 2.10.0",
+ "comrak",
+ "html5ever",
+ "iced",
+ "markup5ever_rcdom",
+]
+
+[[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -2290,6 +2341,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -3000,6 +3061,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jetscii"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3317,12 +3384,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.36.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5fc8802e8797c0dfdd2ce5c21aa0aee21abbc7b3b18559100651b3352a7b63"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
 ]
 
 [[package]]
@@ -4222,6 +4318,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
 name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4267,6 +4402,7 @@ dependencies = [
  "dirs",
  "eframe",
  "egui",
+ "frostmark",
  "fuzzy-matcher",
  "iced",
  "iced-code-editor",
@@ -4412,6 +4548,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "presser"
@@ -5583,6 +5725,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5729,6 +5895,17 @@ dependencies = [
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -6273,6 +6450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6344,6 +6527,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6384,6 +6576,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -6474,6 +6672,12 @@ dependencies = [
  "unicode-vo",
  "usvg 0.29.0",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -6795,6 +6999,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -7766,6 +7982,16 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xml5ever"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f57dd51b88a4b9f99f9b55b136abb86210629d61c48117ddb87f567e51e66be7"
+dependencies = [
+ "log",
+ "markup5ever",
+]
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "process", "io-util", "s
 url = "2.5"
 ropey = "1.6"
 iced-code-editor = { version = "0.3.7", features = ["lsp-process"] }
+frostmark = "0.3"
 
 quinn-proto = "0.11.14"
 bytes = "1.11.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -128,6 +128,8 @@ pub struct App {
     command_palette_selected: usize,
     command_palette_input_id: iced::widget::Id,
 
+    markdown_preview: Option<MarkdownPreviewPane>,
+
     terminal: Terminal,
     terminal_pane: Option<IcedTerminal>,
     terminal_open: bool,
@@ -230,6 +232,8 @@ impl Default for App {
             command_palette: CommandPalette::default(),
             command_palette_selected: 0,
             command_palette_input_id: iced::widget::Id::unique(),
+
+            markdown_preview: None,
 
             terminal: Terminal::default(),
             terminal_pane: {

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,7 @@
 //! This module defines [`App`] and splits its behavior into focused submodules:
 //! event updates, subscriptions, commands, and view builders.
 
+use frostmark::MarkState;
 use iced::widget::{
     button, column, container, markdown, mouse_area, row, scrollable, stack, text, text_input,
 };
@@ -66,6 +67,11 @@ pub struct Tab {
     pub path: PathBuf,
     pub name: String,
     pub kind: TabKind,
+}
+
+pub struct MarkdownPreviewPane {
+    pub source_path: PathBuf,
+    pub state: MarkState,
 }
 
 /// toast notification metadata.

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -63,7 +63,7 @@ impl App {
                     Message::ToggleFullscreen(window::Mode::Fullscreen)
                 });
             }
-            "Preview Markdown" => {
+            "Render Markdown" => {
                 return iced::Task::perform(async {}, |_| Message::PreviewMarkdown);
             }
             _ => {}

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -9,6 +9,43 @@ impl App {
             .is_some_and(|name| name == ".env" || name.starts_with(".env."))
     }
 
+    fn is_markdown_path(path: &std::path::Path) -> bool {
+        matches!(
+            path.extension().and_then(|ext| ext.to_str()),
+            Some("md" | "markdown" | "mdown" | "mdx")
+        )
+    }
+
+    fn active_tab_supports_markdown_preview(&self) -> bool {
+        self.active_tab
+            .and_then(|idx| self.tabs.get(idx))
+            .is_some_and(|tab| {
+                matches!(tab.kind, TabKind::Editor { .. }) && Self::is_markdown_path(&tab.path)
+            })
+    }
+
+    fn sync_markdown_preview_from_active_editor(&mut self) {
+        let Some(preview) = self.markdown_preview.as_mut() else {
+            return;
+        };
+
+        let Some(idx) = self.active_tab else {
+            return;
+        };
+
+        let Some(tab) = self.tabs.get(idx) else {
+            return;
+        };
+
+        if preview.source_path != tab.path {
+            return;
+        }
+
+        if let TabKind::Editor { ref code_editor, .. } = tab.kind {
+            preview.state = frostmark::MarkState::with_html_and_markdown(&code_editor.content());
+        }
+    }
+
     fn open_path_task(path: PathBuf) -> iced::Task<Message> {
         iced::Task::perform(
             async move {
@@ -392,6 +429,8 @@ impl App {
                         }
                     }
 
+                    self.sync_markdown_preview_from_active_editor();
+
                     if let Some(task) = mapped_task {
                         return task;
                     }
@@ -513,6 +552,13 @@ impl App {
                     {
                         code_editor.detach_lsp();
                     }
+                    if self
+                        .markdown_preview
+                        .as_ref()
+                        .is_some_and(|preview| preview.source_path == path)
+                    {
+                        self.markdown_preview = None;
+                    }
                     self.lsp_diagnostics.remove(&path);
                     self.lsp_server_keys.remove(&path);
                     self.tabs.remove(idx);
@@ -541,6 +587,14 @@ impl App {
                     {
                         code_editor.detach_lsp();
                     }
+                    if self
+                        .markdown_preview
+                        .as_ref()
+                        .is_some_and(|preview| preview.source_path == path)
+                    {
+                        self.markdown_preview = None;
+                    }
+
                     self.lsp_diagnostics.remove(&path);
                     self.lsp_server_keys.remove(&path);
                     self.tabs.remove(idx);
@@ -840,25 +894,37 @@ impl App {
                 window::oldest().and_then(move |id| window::maximize(id, true))
             }
             Message::PreviewMarkdown => {
-                if let Some(idx) = self.active_tab {
-                    if let Some(tab) = self.tabs.get(idx) {
-                        if let TabKind::Editor {
-                            ref code_editor, ..
-                        } = tab.kind
-                        {
-                            let text = code_editor.content();
-                            let md_items: Vec<markdown::Item> = markdown::parse(&text).collect();
-                            let preview_name = format!("Preview: {}", tab.name);
-                            let path = tab.path.clone();
-                            self.tabs.push(Tab {
-                                path,
-                                name: preview_name,
-                                kind: TabKind::Preview { md_items },
-                            });
-                            self.active_tab = Some(self.tabs.len() - 1);
-                        }
-                    }
+                let Some(idx) = self.active_tab else {
+                    return iced::Task::none();
+                };
+
+                let Some(tab) = self.tabs.get(idx) else {
+                    return iced::Task::none();
+                };
+
+                if !Self::is_markdown_path(&tab.path) {
+                    return iced::Task::none();
                 }
+
+                let TabKind::Editor { ref code_editor, .. } = tab.kind else {
+                    return iced::Task::none();
+                };
+
+                if self
+                    .markdown_preview
+                    .as_ref()
+                    .is_some_and(|preview| preview.source_path == tab.path)
+                {
+                    self.markdown_preview = None;
+                } else {
+                    self.markdown_preview = Some(MarkdownPreviewPane {
+                        source_path: tab.path.clone(),
+                        state: frostmark::MarkState::with_html_and_markdown(
+                            &code_editor.content(),
+                        ),
+                    });
+                }
+
                 iced::Task::none()
             }
             Message::MarkdownLinkClicked(_uri) => iced::Task::none(),
@@ -1080,7 +1146,8 @@ impl App {
                 iced::Task::none()
             }
             Message::ToggleCommandPalette => {
-                self.command_palette.toggle();
+                let include_markdown_render = self.active_tab_supports_markdown_preview();
+                self.command_palette.toggle(include_markdown_render);
                 self.command_palette_selected = 0;
                 if self.command_palette.open {
                     self.vim_refresh_cursor_style();
@@ -1091,7 +1158,8 @@ impl App {
             }
             Message::CommandPaletteQueryChanged(query) => {
                 self.command_palette.input = query;
-                self.command_palette.filter_commands();
+                self.command_palette
+                    .filter_commands(self.active_tab_supports_markdown_preview());
                 self.command_palette_selected = 0;
                 iced::widget::operation::focus(self.command_palette_input_id.clone())
             }

--- a/src/app/view_editor.rs
+++ b/src/app/view_editor.rs
@@ -1,4 +1,5 @@
 use super::*;
+use frostmark::MarkWidget;
 use iced::widget::column;
 
 impl App {
@@ -201,7 +202,7 @@ impl App {
                         let show_panel = !self.lsp_enabled
                             && self.autocomplete.active
                             && !self.autocomplete.suggestions.is_empty();
-                        if show_panel {
+                        let editor_stack: Element<'_, Message> = if show_panel {
                             // ── Purple autocomplete modal with navigation ───────────────────
                             let kind_color = |kind: &crate::autocomplete::types::SuggestionKind| {
                                 use crate::autocomplete::types::SuggestionKind;
@@ -370,16 +371,59 @@ impl App {
                                 .width(Length::Fill)
                                 .height(Length::Fill);
 
-                            return stack![editor, positioned_panel, lsp_overlay]
+                            stack![editor, positioned_panel, lsp_overlay]
                                 .width(Length::Fill)
                                 .height(Length::Fill)
-                                .into();
-                        }
+                                .into()
+                        } else {
+                            stack![editor, lsp_overlay]
+                                .width(Length::Fill)
+                                .height(Length::Fill)
+                                .into()
+                        };
 
-                        return stack![editor, lsp_overlay]
-                            .width(Length::Fill)
+                        if let Some(preview) = self
+                            .markdown_preview
+                            .as_ref()
+                            .filter(|preview| preview.source_path == tab.path)
+                        {
+                            let separator = container(text(""))
+                                .width(Length::Fixed(1.0))
+                                .height(Length::Fill)
+                                .style(|_theme| container::Style {
+                                    background: Some(iced::Background::Color(Color::from_rgba(
+                                        1.0, 1.0, 1.0, 0.08,
+                                    ))),
+                                    ..Default::default()
+                                });
+
+                            let preview_panel = container(
+                                scrollable(
+                                    container(MarkWidget::new(&preview.state))
+                                        .padding(16)
+                                        .width(Length::Fill),
+                                )
+                                .height(Length::Fill),
+                            )
+                            .width(Length::FillPortion(1))
+                            .height(Length::Fill)
+                            .style(|_theme| container::Style {
+                                background: Some(iced::Background::Color(theme().bg_secondary)),
+                                ..Default::default()
+                            });
+
+                            return row![
+                                container(editor_stack)
+                                    .width(Length::FillPortion(1))
+                                    .height(Length::Fill),
+                                separator,
+                                preview_panel,
+                            ]
                             .height(Length::Fill)
                             .into();
+                        }
+
+                        return editor_stack;
                     }
                     TabKind::Preview { md_items } => {
                         return scrollable(

--- a/src/features/command_palette.rs
+++ b/src/features/command_palette.rs
@@ -16,7 +16,21 @@ pub struct CommandPalette {
 
 impl Default for CommandPalette {
     fn default() -> Self {
-        let commands = vec![
+        let commands = Self::commands_for(false);
+        let filtered = commands.clone();
+
+        Self {
+            open: false,
+            input: String::new(),
+            commands,
+            filtered_commands: filtered,
+        }
+    }
+}
+
+impl CommandPalette {
+    fn commands_for(include_markdown_render: bool) -> Vec<Command> {
+        let mut commands = vec![
             Command {
                 name: "Theme".to_string(),
                 description: "Open theme settings".to_string(),
@@ -59,22 +73,21 @@ impl Default for CommandPalette {
             },
         ];
 
-        let filtered = commands.clone();
-
-        Self {
-            open: false,
-            input: String::new(),
-            commands,
-            filtered_commands: filtered,
+        if include_markdown_render {
+            commands.push(Command {
+                name: "Render Markdown".to_string(),
+                description: "Open a live markdown preview beside the editor".to_string(),
+            });
         }
-    }
-}
 
-impl CommandPalette {
-    pub fn toggle(&mut self) {
+        commands
+    }
+
+    pub fn toggle(&mut self, include_markdown_render: bool) {
         self.open = !self.open;
         if self.open {
             self.input.clear();
+            self.commands = Self::commands_for(include_markdown_render);
             self.filtered_commands = self.commands.clone();
         }
     }
@@ -85,7 +98,8 @@ impl CommandPalette {
         self.filtered_commands.clear();
     }
 
-    pub fn filter_commands(&mut self) {
+    pub fn filter_commands(&mut self, include_markdown_render: bool) {
+        self.commands = Self::commands_for(include_markdown_render);
         let input_lower = self.input.to_lowercase();
 
         if input_lower.is_empty() {


### PR DESCRIPTION
Added markdown rendering using command palette.

When user opens command palette while in a `.md` or similar markdown file, they will have the ability to enable the `Render Markdown` option