### PR TITLE
54 - Number modifiers for file selection

### DIFF
--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -1814,6 +1814,12 @@ impl App {
                 self.vim_refresh_cursor_style();
                 iced::Task::none()
             }
+            Message::SelectTabByIndex(idx) => {
+                if idx < self.tabs.len() {
+                    return self.update(Message::TabSelected(idx));
+                }
+                iced::Task::none()
+            }
             Message::SaveAs => iced::Task::perform(
                 async {
                     rfd::AsyncFileDialog::new()

--- a/src/features/find_replace.rs
+++ b/src/features/find_replace.rs
@@ -1,7 +1,6 @@
 /// Find and Replace - In-editor find and replace with case-sensitive toggle,
 /// match navigation, replace-one, and replace-all.
 /// Ported from pinel's hotkey/find_replace.rs, adapted for iced.
-
 pub struct FindReplace {
     pub open: bool,
     pub find_text: String,

--- a/src/message.rs
+++ b/src/message.rs
@@ -96,6 +96,7 @@ pub enum Message {
 
     NewFile,
     SaveAs,
+    SelectTabByIndex(usize),
 
     WakaTimeApiKeyChanged(String),
     WakaTimeApiKeyHoverStart,

--- a/src/subscriptions/keyboard.rs
+++ b/src/subscriptions/keyboard.rs
@@ -47,6 +47,15 @@ pub fn shortcuts() -> Subscription<Message> {
                         "j" | "J" => return Some(Message::ToggleTerminal),
                         "f" | "F" => return Some(Message::ToggleFindReplace),
                         "n" | "N" => return Some(Message::NewFile),
+                        "1" => return Some(Message::SelectTabByIndex(0)),
+                        "2" => return Some(Message::SelectTabByIndex(1)),
+                        "3" => return Some(Message::SelectTabByIndex(2)),
+                        "4" => return Some(Message::SelectTabByIndex(3)),
+                        "5" => return Some(Message::SelectTabByIndex(4)),
+                        "6" => return Some(Message::SelectTabByIndex(5)),
+                        "7" => return Some(Message::SelectTabByIndex(6)),
+                        "8" => return Some(Message::SelectTabByIndex(7)),
+                        "9" => return Some(Message::SelectTabByIndex(8)),
                         _ => {}
                     }
                 }


### PR DESCRIPTION
# Number modifiers for file selection

This PR is an extension of issue #54 and aims to allow users to use number modifiers in order to navigate the currently open files.

## Usage

Ensure you are currently in a directory and have a few files open.

Windows/Linux:
Control + `number (1, 9)`

MacOS:
Command + `number (1, 9)`

## Demo

https://github.com/user-attachments/assets/ee082be5-7955-4451-a114-524d7ebd0614
